### PR TITLE
Update navbar links to use relative paths

### DIFF
--- a/SchedulinkXM/app/views/partials/navbar.php
+++ b/SchedulinkXM/app/views/partials/navbar.php
@@ -68,13 +68,13 @@
         <div class="collapse navbar-collapse" id="navbarNav">
             <ul class="navbar-nav me-auto">
                 <li class="nav-item">
-                    <a class="nav-link" href="exams/list.php">Exams</a>
+                    <a class="nav-link" href="../exams/list.php">Exams</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="lecturers/list.php">Lecturers</a>
+                    <a class="nav-link" href="../lecturers/list.php">Lecturers</a>
                 </li>
                 <li class="nav-item">
-                    <a class="nav-link" href="halls/list.php">Halls</a>
+                    <a class="nav-link" href="../halls/list.php">Halls</a>
                 </li>
                 <li class="nav-item">
                     <a class="nav-link" href="/reports/allocations">Reports</a>


### PR DESCRIPTION
This pull request updates relative paths in the navigation bar of the `SchedulinkXM` application to ensure proper linking from nested directories.

Navigation bar link updates:

* [`SchedulinkXM/app/views/partials/navbar.php`](diffhunk://#diff-eb51effbf1bd4ef535580196575eeb7b004a4e11619c1ac81d28cab4d25501b2L71-R77): Adjusted the relative paths for the "Exams," "Lecturers," and "Halls" links to include an additional `../` prefix, ensuring they work correctly when accessed from nested directories.